### PR TITLE
docs: curate dsh-chat-import (category + migration scenario)

### DIFF
--- a/data/curated.json
+++ b/data/curated.json
@@ -5,7 +5,8 @@
     "fuhefei/dsh-sentinel": "agents-workflows",
     "omdsh-dev/dsh-genui": "ui-experience",
     "ZSeven-W/dsh-openpencil": "media-vision",
-    "vlln/whale-girl": "ui-experience"
+    "vlln/whale-girl": "ui-experience",
+    "Nwflower/dsh-chat-import": "integrations-sharing"
   },
   "scenarios": [
     {
@@ -63,6 +64,13 @@
       "repos": ["vlln/whale-girl"],
       "why_zh": "可拖拽、投喂和玩耍的积累型鲸鱼娘桌面伙伴。",
       "why_en": "A draggable companion with feeding, play, and persistent progression."
+    },
+    {
+      "goal_zh": "把其他工具的历史会话搬进 DSH",
+      "goal_en": "Migrate chat histories from other tools into DSH",
+      "repos": ["Nwflower/dsh-chat-import"],
+      "why_zh": "全保真导入 Claude Code / Codex / ChatGPT / Cursor 的聊天记录（含工具调用/思考块），导入后可直接续聊。",
+      "why_en": "Full-fidelity import of Claude Code / Codex / ChatGPT / Cursor transcripts (tools + thinking) as resumable DSH sessions."
     }
   ],
   "starter_kits": [


### PR DESCRIPTION
## 收录请求

- 仓库: https://github.com/Nwflower/dsh-chat-import
- 改动: 仅 data/curated.json（人工推荐数据源）：
  1. category_overrides: `Nwflower/dsh-chat-import` -> `integrations-sharing`（默认会被 /harness/ 正则分进 agents-workflows，集成/迁移主题更贴切）
  2. 新增 scenario: 「把其他工具的历史会话搬进 DSH / Migrate chat histories from other tools into DSH」
- 说明: 生成文件（README.md / README_EN.md / CATALOG.md / data/repositories.json）**未随 PR 提交**——当前仓库快照落后线上较多（212 → 353 仓库），全量重新生成会产生 7500+ 行噪音 diff；合并后跑一次 `node scripts/update.mjs` 或等每日 update-catalog CI 刷新即可（本地已验证生成结果：我们的条目进入 repositories.json 且分类为 integrations-sharing）
- 收录条件: 仓库公开 + dsh-plugin topic ✓；npm 已发布（dsh-chat-import@0.1.0）；npm test 42/42