### PR TITLE
chore: harden curated data pipeline

### DIFF
--- a/.github/workflows/validate-curated.yml
+++ b/.github/workflows/validate-curated.yml
@@ -1,0 +1,30 @@
+name: Validate curated data
+
+on:
+  pull_request:
+    paths:
+      - 'data/curated.json'
+      - 'scripts/**'
+      - '.github/workflows/validate-curated.yml'
+
+permissions:
+  contents: read
+
+concurrency:
+  group: validate-curated-${{ github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  validate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v7
+      - uses: actions/setup-node@v7
+        with:
+          node-version: 22
+      - name: Validate data/curated.json
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: node scripts/validate-curated.mjs
+      - name: Rebuild pages from the stored snapshot
+        run: node scripts/update.mjs --from-snapshot

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -13,17 +13,29 @@ Thank you for helping maintain Awesome DSH Plugin.
 - Descriptions should be accurate and concise, without unverifiable marketing claims.
 - Important status such as archival, missing license, or evident security risk should be disclosed.
 
-## 更新数据 / Refreshing data
+## 推荐一个插件 / Recommending a plugin
+
+人工推荐、场景导航和分类覆盖写在 `data/curated.json`。这是唯一需要手工编辑的文件；不要直接修改生成后的推荐区块。
+
+Curated recommendations, scenario navigation, and category overrides live in `data/curated.json`. It is the only file you need to edit by hand; do not modify generated recommendation sections directly.
+
+**只改 `data/curated.json` 的 PR 不要提交生成文件。** `README.md`、`README_EN.md`、`CATALOG.md` 和 `data/repositories.json` 由每日 `update-catalog` 工作流统一刷新；随 PR 附带它们会产生大量噪音 diff，并与自动提交冲突。
+
+**Pull requests that only touch `data/curated.json` should not include generated files.** `README.md`, `README_EN.md`, `CATALOG.md`, and `data/repositories.json` are refreshed by the daily `update-catalog` workflow; committing them alongside a curation change creates a large noise diff and conflicts with the automated commit.
+
+提交前本地自检 / Check your change locally before submitting:
 
 ```bash
-node scripts/update.mjs
+node scripts/validate-curated.mjs
 ```
 
-人工推荐、场景导航和分类覆盖写在 `data/curated.json`；不要直接编辑生成后的推荐区块。
+它会校验分类名、双语字段，并通过 GitHub API 确认被引用的仓库公开、未归档且带有 `dsh-plugin` Topic。同样的检查会在 PR 上自动运行。
 
-Curated recommendations, scenario navigation, and category overrides live in `data/curated.json`; do not edit generated recommendation sections directly.
+It validates category names and bilingual fields, and confirms through the GitHub API that every referenced repository is public, not archived, and carries the `dsh-plugin` topic. The same check runs automatically on pull requests.
 
-刷新最新 GitHub 数据：
+## 更新数据 / Refreshing data
+
+刷新最新 GitHub 数据并重新生成页面：
 
 ```bash
 node scripts/update.mjs
@@ -35,6 +47,12 @@ node scripts/update.mjs
 node scripts/update.mjs --from-snapshot
 ```
 
-提交前请确认 `README.md`、`README_EN.md`、`CATALOG.md` 与 `data/repositories.json` 保持一致。
+刚创建的仓库会晚于 `data/repositories.json` 快照，因此 `--from-snapshot` 会提示该条目缺失并跳过它；这属于正常现象，用完整的 `node scripts/update.mjs` 验证即可。
 
-Before submitting, make sure `README.md`, `README_EN.md`, `CATALOG.md`, and `data/repositories.json` stay in sync.
+A newly created repository is younger than the stored `data/repositories.json` snapshot, so `--from-snapshot` reports it as missing and skips it. That is expected — verify with a full `node scripts/update.mjs` run instead.
+
+## 修改生成逻辑 / Changing the generator
+
+改动 `scripts/` 时，请在 PR 中附带重新生成的 `README.md`、`README_EN.md` 和 `CATALOG.md`，以便审阅者看到输出变化。
+
+When changing `scripts/`, include the regenerated `README.md`, `README_EN.md`, and `CATALOG.md` in the pull request so reviewers can see how the output changes.

--- a/scripts/categories.mjs
+++ b/scripts/categories.mjs
@@ -1,0 +1,20 @@
+// Shared category definitions for scripts/update.mjs and scripts/validate-curated.mjs.
+// Each rule is [key, label_zh, label_en, pattern]; the fallback carries no pattern.
+
+export const categoryRules = [
+  ['ecosystem-resources', '生态与资源', 'Ecosystem & Resources', /awesome|hub|find-plugin|plugin-registry|plugin-check|plugin-dev|template|community/i],
+  ['ui-experience', '界面与体验', 'UI & Experience', /\bui\b|web-ui|sidebar|navbar|side-panel|skin|theme|css|chat-width|focus-chat|input|paste|status|notification|split-pane|annotation|genui|emoji|sticker|pet|whale/i],
+  ['media-vision', '设计、媒体与视觉', 'Design, Media & Vision', /vision|photo|canvas|aigc|visual|multimodal|qwen-mm|image|openpencil|design/i],
+  ['web-browser', '网页与浏览器', 'Web & Browser', /web|browser|archive|computer-use|spotlight|launcher|desktop|deeplink|drag-and-drop/i],
+  ['integrations-sharing', '集成与分享', 'Integrations & Sharing', /share|github|telegram|qq|zotero|acp|connect|remote|teleport|tonghuashun|stock-market|identity/i],
+  ['knowledge-research', '知识与研究', 'Knowledge & Research', /knowledge|research|kb|distill|mnemon|math|lean|sieve|mineru|memory|scholar/i],
+  ['developer-tools', '开发者工具', 'Developer Tools', /vscode|git|diff|inspect|custom-tool|tool-search|doctor|runtime|sandbox|encoding|schema|regex|json|csv|calculator|\bstat\b/i],
+  ['agents-workflows', 'Agent、自动化与工作流', 'Agents, Automation & Workflows', /agent|workflow|harness|advisor|approval|subagent|budget|fallback|deep-research|evolve|team|loop|sentinel|checkpoint/i],
+];
+
+export const categoryFallback = ['utilities', '实用工具与其他', 'Utilities & Other'];
+
+// Overrides may target any category, including the fallback.
+export const assignableCategories = [...categoryRules, categoryFallback];
+
+export const categoryKeys = assignableCategories.map(([key]) => key);

--- a/scripts/update.mjs
+++ b/scripts/update.mjs
@@ -1,25 +1,14 @@
 #!/usr/bin/env node
 
-import { mkdir, readFile, writeFile } from 'node:fs/promises';
+import { appendFile, mkdir, readFile, writeFile } from 'node:fs/promises';
 import { dirname, resolve } from 'node:path';
 import { fileURLToPath } from 'node:url';
+import { assignableCategories, categoryFallback, categoryRules } from './categories.mjs';
 
 const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
 const query = 'topic:dsh-plugin';
 const fromSnapshot = process.argv.includes('--from-snapshot');
 
-const categoryRules = [
-  ['ecosystem-resources', '生态与资源', 'Ecosystem & Resources', /awesome|hub|find-plugin|plugin-registry|plugin-check|plugin-dev|template|community/i],
-  ['ui-experience', '界面与体验', 'UI & Experience', /\bui\b|web-ui|sidebar|navbar|side-panel|skin|theme|css|chat-width|focus-chat|input|paste|status|notification|split-pane|annotation|genui|emoji|sticker|pet|whale/i],
-  ['media-vision', '设计、媒体与视觉', 'Design, Media & Vision', /vision|photo|canvas|aigc|visual|multimodal|qwen-mm|image|openpencil|design/i],
-  ['web-browser', '网页与浏览器', 'Web & Browser', /web|browser|archive|computer-use|spotlight|launcher|desktop|deeplink|drag-and-drop/i],
-  ['integrations-sharing', '集成与分享', 'Integrations & Sharing', /share|github|telegram|qq|zotero|acp|connect|remote|teleport|tonghuashun|stock-market|identity/i],
-  ['knowledge-research', '知识与研究', 'Knowledge & Research', /knowledge|research|kb|distill|mnemon|math|lean|sieve|mineru|memory|scholar/i],
-  ['developer-tools', '开发者工具', 'Developer Tools', /vscode|git|diff|inspect|custom-tool|tool-search|doctor|runtime|sandbox|encoding|schema|regex|json|csv|calculator|\bstat\b/i],
-  ['agents-workflows', 'Agent、自动化与工作流', 'Agents, Automation & Workflows', /agent|workflow|harness|advisor|approval|subagent|budget|fallback|deep-research|evolve|team|loop|sentinel|checkpoint/i],
-];
-
-const categoryFallback = ['utilities', '实用工具与其他', 'Utilities & Other'];
 const curated = JSON.parse(await readFile(resolve(root, 'data/curated.json'), 'utf8'));
 const categoryOverrides = new Map(
   Object.entries(curated.category_overrides || {}).map(([fullName, category]) => [fullName.toLowerCase(), category]),
@@ -40,11 +29,14 @@ async function fetchPage(page) {
   return response.json();
 }
 
+const unknownOverrides = new Set();
+
 function categoryFor(repo) {
   const override = categoryOverrides.get(repo.full_name.toLowerCase());
   if (override) {
-    const match = categoryRules.find(([key]) => key === override);
+    const match = assignableCategories.find(([key]) => key === override);
     if (match) return match;
+    unknownOverrides.add(`${repo.full_name} -> ${override}`);
   }
   const haystack = [repo.name, repo.description, ...(repo.topics || [])].filter(Boolean).join(' ');
   return categoryRules.find((rule) => rule[3].test(haystack)) || categoryFallback;
@@ -122,14 +114,22 @@ const totals = {
 
 const esc = (value) => String(value ?? '').replaceAll('|', '\\|').replaceAll('\n', ' ');
 const repoName = (fullName) => fullName.split('/')[1];
+// A curated entry can drop out of the topic snapshot when its repository is deleted,
+// made private, or loses the dsh-plugin topic — and a freshly submitted repository is
+// simply newer than the stored snapshot. Neither case should fail the whole refresh:
+// skip the entry, keep the catalog building, and report the gap at the end.
+const missingCurated = new Set();
 const repoFor = (fullName) => {
   const repo = repoMap.get(fullName.toLowerCase());
-  if (!repo) throw new Error(`Curated repository is missing from the topic snapshot: ${fullName}`);
+  if (!repo) {
+    missingCurated.add(fullName);
+    return null;
+  }
   return repo;
 };
 const repoLink = (fullName) => {
   const repo = repoFor(fullName);
-  return `[${repoName(repo.full_name)}](${repo.html_url})`;
+  return repo ? `[${repoName(repo.full_name)}](${repo.html_url})` : null;
 };
 const updated = (repo) => repo.updated_at.slice(0, 10);
 
@@ -137,26 +137,30 @@ function scenarioTable(language) {
   const header = language === 'zh'
     ? '| 我想要…… | 推荐从这里开始 | 为什么 |\n| --- | --- | --- |'
     : '| I want to… | Start here | Why |\n| --- | --- | --- |';
-  const rows = curated.scenarios.map((item) => {
-    const links = item.repos.map(repoLink).join(' · ');
-    return `| ${item[`goal_${language}`]} | ${links} | ${item[`why_${language}`]} |`;
-  });
+  const rows = curated.scenarios
+    .map((item) => ({ item, links: item.repos.map(repoLink).filter(Boolean) }))
+    .filter((entry) => entry.links.length)
+    .map(({ item, links }) => `| ${item[`goal_${language}`]} | ${links.join(' · ')} | ${item[`why_${language}`]} |`);
   return `${header}\n${rows.join('\n')}`;
 }
 
 function starterKits(language) {
-  return curated.starter_kits.map((kit) => {
-    const links = kit.repos.map(repoLink).join(' · ');
-    return `### ${kit[`title_${language}`]}\n\n${kit[`summary_${language}`]}\n\n${links}`;
-  }).join('\n\n');
+  return curated.starter_kits
+    .map((kit) => ({ kit, links: kit.repos.map(repoLink).filter(Boolean) }))
+    .filter((entry) => entry.links.length)
+    .map(({ kit, links }) => `### ${kit[`title_${language}`]}\n\n${kit[`summary_${language}`]}\n\n${links.join(' · ')}`)
+    .join('\n\n');
 }
 
 function editorPicks(language) {
-  return curated.editor_picks.map((pick) => {
-    const repo = repoFor(pick.repo);
-    const labels = pick[`labels_${language}`].map((label) => `\`${label}\``).join(' ');
-    return `### [${pick[`title_${language}`]}](${repo.html_url})\n\n${pick[`summary_${language}`]}\n\n${labels}`;
-  }).join('\n\n');
+  return curated.editor_picks
+    .map((pick) => ({ pick, repo: repoFor(pick.repo) }))
+    .filter((entry) => entry.repo)
+    .map(({ pick, repo }) => {
+      const labels = pick[`labels_${language}`].map((label) => `\`${label}\``).join(' ');
+      return `### [${pick[`title_${language}`]}](${repo.html_url})\n\n${pick[`summary_${language}`]}\n\n${labels}`;
+    })
+    .join('\n\n');
 }
 
 function recentProjects(language) {
@@ -203,3 +207,26 @@ await writeFile(resolve(root, 'README_EN.md'), readmeEn);
 await writeFile(resolve(root, 'CATALOG.md'), catalog);
 
 console.log(`${fromSnapshot ? 'Generated from snapshot' : 'Updated'} ${repositories.length} repositories at ${snapshot.fetched_at}`);
+
+const warnings = [];
+if (missingCurated.size) {
+  warnings.push(
+    `Curated entries missing from the topic snapshot (skipped in the generated pages): ${[...missingCurated].join(', ')}`,
+    fromSnapshot
+      ? 'Snapshot mode only sees stored data — run `node scripts/update.mjs` to check against live GitHub results.'
+      : 'These repositories no longer appear under the dsh-plugin topic. Remove or replace them in data/curated.json.',
+  );
+}
+if (unknownOverrides.size) {
+  warnings.push(`Unknown category_overrides values (ignored, repository fell back to pattern matching): ${[...unknownOverrides].join(', ')}`);
+}
+
+if (warnings.length) {
+  for (const warning of warnings) console.warn(`Warning: ${warning}`);
+  if (process.env.GITHUB_STEP_SUMMARY) {
+    await appendFile(
+      process.env.GITHUB_STEP_SUMMARY,
+      `### Curated data warnings\n\n${warnings.map((warning) => `- ${warning}`).join('\n')}\n`,
+    );
+  }
+}

--- a/scripts/validate-curated.mjs
+++ b/scripts/validate-curated.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+
+// Validates data/curated.json before it reaches main.
+//
+// Repository references are checked against the live GitHub API rather than
+// data/repositories.json: the stored snapshot always lags behind, so a freshly
+// submitted repository would otherwise look invalid.
+
+import { readFile } from 'node:fs/promises';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+import { categoryKeys } from './categories.mjs';
+
+const root = resolve(dirname(fileURLToPath(import.meta.url)), '..');
+const errors = [];
+const validCategories = new Set(categoryKeys);
+
+let curated;
+try {
+  curated = JSON.parse(await readFile(resolve(root, 'data/curated.json'), 'utf8'));
+} catch (error) {
+  console.error(`data/curated.json could not be parsed: ${error.message}`);
+  process.exit(1);
+}
+
+for (const [fullName, category] of Object.entries(curated.category_overrides || {})) {
+  if (!validCategories.has(category)) {
+    errors.push(`category_overrides["${fullName}"]: unknown category "${category}" (valid: ${categoryKeys.join(', ')})`);
+  }
+}
+
+const referenced = new Set();
+
+function checkEntry(entry, label, fields) {
+  for (const field of fields) {
+    const value = entry[field];
+    if (value === undefined || value === null || value === '' || (Array.isArray(value) && !value.length)) {
+      errors.push(`${label}: missing or empty "${field}"`);
+    }
+  }
+  for (const fullName of entry.repos || (entry.repo ? [entry.repo] : [])) {
+    if (typeof fullName !== 'string' || !/^[\w.-]+\/[\w.-]+$/.test(fullName)) {
+      errors.push(`${label}: "${fullName}" is not a valid owner/repo reference`);
+      continue;
+    }
+    referenced.add(fullName);
+  }
+}
+
+(curated.scenarios || []).forEach((item, index) =>
+  checkEntry(item, `scenarios[${index}]`, ['goal_zh', 'goal_en', 'why_zh', 'why_en', 'repos']));
+(curated.starter_kits || []).forEach((kit, index) =>
+  checkEntry(kit, `starter_kits[${index}]`, ['title_zh', 'title_en', 'summary_zh', 'summary_en', 'repos']));
+(curated.editor_picks || []).forEach((pick, index) =>
+  checkEntry(pick, `editor_picks[${index}]`, ['repo', 'title_zh', 'title_en', 'summary_zh', 'summary_en', 'labels_zh', 'labels_en']));
+
+const headers = {
+  Accept: 'application/vnd.github+json',
+  'User-Agent': 'awesome-dsh-plugin',
+  'X-GitHub-Api-Version': '2022-11-28',
+};
+if (process.env.GITHUB_TOKEN) headers.Authorization = `Bearer ${process.env.GITHUB_TOKEN}`;
+
+await Promise.all([...referenced].map(async (fullName) => {
+  let response;
+  try {
+    response = await fetch(`https://api.github.com/repos/${fullName}`, { headers });
+  } catch (error) {
+    errors.push(`${fullName}: GitHub API request failed (${error.message})`);
+    return;
+  }
+  if (response.status === 404) {
+    errors.push(`${fullName}: repository not found — deleted, renamed, or not public`);
+    return;
+  }
+  if (!response.ok) {
+    errors.push(`${fullName}: GitHub API ${response.status} ${await response.text()}`);
+    return;
+  }
+  const repo = await response.json();
+  if (repo.private) errors.push(`${fullName}: repository is private`);
+  if (repo.archived) errors.push(`${fullName}: repository is archived`);
+  if (repo.disabled) errors.push(`${fullName}: repository is disabled`);
+  if (!(repo.topics || []).includes('dsh-plugin')) {
+    errors.push(`${fullName}: missing the "dsh-plugin" topic, so it never enters the catalog snapshot`);
+  }
+  if (repo.full_name.toLowerCase() !== fullName.toLowerCase()) {
+    errors.push(`${fullName}: repository was renamed to "${repo.full_name}" — update the reference`);
+  }
+}));
+
+if (errors.length) {
+  console.error(`data/curated.json validation failed with ${errors.length} problem(s):\n`);
+  for (const error of errors) console.error(`  - ${error}`);
+  process.exit(1);
+}
+
+console.log(`data/curated.json is valid — ${referenced.size} referenced repositories checked against the GitHub API.`);


### PR DESCRIPTION
## 背景

一条 curated 推荐只要从 topic 快照里消失，`repoFor()` 就会抛错并让整个目录刷新失败。这在两种情况下都会发生：

- 新提交的仓库比存储的快照更新（#1 就是这个情况，`--from-snapshot` 直接崩）
- 已收录仓库丢失 `dsh-plugin` topic、转私有或被删除（会让每日定时任务整个变红）

也就是说，单条失效推荐可以拖垮整个目录刷新。

## 改动

- **失效条目降级而非崩溃**：跳过缺失的 curated 条目，汇总为警告并写入 GitHub step summary，维护者仍能看到问题。
- **分类规则抽出共享模块** `scripts/categories.mjs`，生成器与校验器共用一份定义。
- **修复 `category_overrides` 无法指向 `utilities`**：之前只在 `categoryRules` 中查找，把仓库归到 fallback 分类是无声失效的；非法分类值现在也会告警。
- **新增 PR 阶段校验** `scripts/validate-curated.mjs` + `validate-curated.yml`：校验分类名、双语字段、仓库引用格式，并通过**实时 GitHub API**（而非总是滞后的快照）确认仓库公开、未归档、带 topic、未被重命名。
- **修正 CONTRIBUTING 的自相矛盾**：原文要求提交前保持生成文件同步，但对只改 `curated.json` 的收录 PR 照做会产生数千行噪音 diff 并与 bot 的自动提交冲突。

## 验证

| 场景 | 结果 |
|---|---|
| 加固脚本 + 现有数据 `--from-snapshot` | 与已提交页面逐字节相同，无回归 |
| 加固脚本 + #1 数据（仓库不在快照） | exit 0，跳过并告警（此前崩溃） |
| 生成页面 | 无 `undefined`、无空链接，其余条目完好 |
| 校验器 / 现有数据 | 通过，10 个引用仓库全部核验 |
| 校验器 / 人为坏数据 | exit 1，捕获非法分类、缺失 `goal_en`、不存在的仓库 |
| `utilities` override | 现在生效 |

## 注意

`pull_request` workflow 的定义取自合并结果，因此本 PR 合并后，#1 需要一次 rebase/push 才会跑上新校验。