### PR TITLE
feat: add wanzhiwei5/dsh-skin-amis (Amis pink-white skin)

### DIFF
--- a/data/curated.json
+++ b/data/curated.json
@@ -21,119 +21,158 @@
     {
       "goal_zh": "想要独立的桌面客户端，而不是浏览器标签页",
       "goal_en": "Run DSH as a standalone desktop app, not a browser tab",
-      "repos": ["bruc3van/dsh-desktop"],
+      "repos": [
+        "bruc3van/dsh-desktop"
+      ],
       "why_zh": "开箱即用的桌面体验：自动复用本机已运行的实例，或用内置运行时一键启动，无需安装 Node.js/CLI；支持远程实例连接、托盘常驻和异常恢复。",
       "why_en": "An out-of-the-box desktop experience: auto-reuse a running local instance or launch the bundled runtime with no Node.js/CLI install required, plus remote-instance connections, tray residency, and crash recovery."
     },
     {
       "goal_zh": "更方便地管理和发现插件",
       "goal_en": "Manage and discover plugins",
-      "repos": ["vlln/plugin-registry"],
+      "repos": [
+        "vlln/plugin-registry"
+      ],
       "why_zh": "在浏览器面板中管理 repository 插件，并提供开发引导。",
       "why_en": "Manage repository plugins in a browser console with plugin-development guidance."
     },
     {
       "goal_zh": "把现有业务代码转成 Agent 可调用能力",
       "goal_en": "Turn existing application code into agent-callable capabilities",
-      "repos": ["leechen298/Code2Skill"],
+      "repos": [
+        "leechen298/Code2Skill"
+      ],
       "why_zh": "从用户授权的前端、后端或全栈源码生成 Function、MCP Tools、业务 Skills 和离线测试，并可作为 DSH Bundle 安装。",
       "why_en": "Generate Functions, MCP tools, workflow Skills, and offline tests from user-authorized frontend, backend, or full-stack source code, packaged as an installable DSH bundle."
     },
     {
       "goal_zh": "看清后台任务进度",
       "goal_en": "Track background tasks",
-      "repos": ["vlln/dsh-task-status"],
+      "repos": [
+        "vlln/dsh-task-status"
+      ],
       "why_zh": "在对话页显示任务进度和实时输出 tail。",
       "why_en": "Show task progress and a live output tail in the conversation view."
     },
     {
       "goal_zh": "定时或按事件唤醒 Agent",
       "goal_en": "Wake an agent on a schedule or event",
-      "repos": ["vlln/dsh-loop", "fuhefei/dsh-sentinel"],
+      "repos": [
+        "vlln/dsh-loop",
+        "fuhefei/dsh-sentinel"
+      ],
       "why_zh": "覆盖周期任务，以及文件、命令、HTTP、进程和 Webhook 事件。",
       "why_en": "Cover scheduled runs plus file, command, HTTP, process, and webhook events."
     },
     {
       "goal_zh": "请求经常因网络波动或超时中断，不想每次都手动补一句「继续」",
       "goal_en": "Keep requests from dying to network hiccups and timeouts without manually saying \"continue\" every time",
-      "repos": ["HsiangNianian/dsh-auto-continue"],
+      "repos": [
+        "HsiangNianian/dsh-auto-continue"
+      ],
       "why_zh": "监听实时事件流，回合因非人为原因失败后自动补发「继续」：错误分类只恢复临时性故障，自适应退避避免对故障上游狂轰滥炸，支持模板化继续文本与浏览器通知，参数可在插件设置卡片中调整。",
       "why_en": "Watches the live event streams and auto-sends a queued \"继续\" after non-human failures: error classification resumes only transient faults, adaptive backoff avoids hammering a broken upstream, and templated continue text plus browser notifications keep you in the loop — all configurable from the plugin settings card."
     },
     {
       "goal_zh": "更顺手地阅读和操作长对话",
       "goal_en": "Navigate and annotate long conversations",
-      "repos": ["vlln/dsh-navbar", "omdsh-dev/dsh-annotation"],
+      "repos": [
+        "vlln/dsh-navbar",
+        "omdsh-dev/dsh-annotation"
+      ],
       "why_zh": "快速跳转用户消息节点，并像 Codex 一样选中文本批注。",
       "why_en": "Jump between user-message nodes and attach Codex-style annotations."
     },
     {
       "goal_zh": "在对话中生成交互式界面",
       "goal_en": "Render interactive UI in chat",
-      "repos": ["omdsh-dev/dsh-genui"],
+      "repos": [
+        "omdsh-dev/dsh-genui"
+      ],
       "why_zh": "在回复中渲染图表、表单、测验、Mermaid 和 3D 场景。",
       "why_en": "Render charts, forms, quizzes, Mermaid diagrams, and 3D scenes inline."
     },
     {
       "goal_zh": "让 Agent 操作真实设计画布",
       "goal_en": "Let agents operate a real design canvas",
-      "repos": ["ZSeven-W/dsh-openpencil"],
+      "repos": [
+        "ZSeven-W/dsh-openpencil"
+      ],
       "why_zh": "创建、编辑、预览和验证可交互的多页面 OpenPencil 设计稿。",
       "why_en": "Create, edit, preview, and validate interactive multi-page OpenPencil designs."
     },
     {
       "goal_zh": "给 DSH 增加视觉理解能力",
       "goal_en": "Add visual understanding to DSH",
-      "repos": ["Anionex/dsh-vision-toolkit", "ycp424c/dsh-luna-vision-bridge"],
+      "repos": [
+        "Anionex/dsh-vision-toolkit",
+        "ycp424c/dsh-luna-vision-bridge"
+      ],
       "why_zh": "覆盖图片问答、长截图 OCR、UI 还原、定位和像素对比；纯文本模型也可以通过 Luna 转写桥接继续处理图片。",
       "why_en": "Add image Q&A, long-screenshot OCR, UI restoration, grounding, and pixel diffs — or bridge pure-text models to image input via a Luna transcription adapter."
     },
     {
       "goal_zh": "在开发对话里直接检查和操作当前网页",
       "goal_en": "Inspect and operate the current web page from your dev conversation",
-      "repos": ["ycp424c/dsh-browser-bridge"],
+      "repos": [
+        "ycp424c/dsh-browser-bridge"
+      ],
       "why_zh": "把完整 DSH Web 嵌进 Chrome 侧边栏，按 prompt 显式授权当前标签页，DSH 能在同一对话里读取 DOM、样式、console 报错并操作页面，无需另开浏览器专用对话。",
       "why_en": "Embeds the full DSH Web in a Chrome side panel; grant the current tab per prompt so DSH can read the DOM, styles, and console errors and interact with the page inside your existing conversation instead of a separate browser chat."
     },
     {
       "goal_zh": "给工作区增加一个陪伴型宠物",
       "goal_en": "Add a companion to the workspace",
-      "repos": ["vlln/whale-girl"],
+      "repos": [
+        "vlln/whale-girl"
+      ],
       "why_zh": "可拖拽、投喂和玩耍的积累型鲸鱼娘桌面伙伴。",
       "why_en": "A draggable companion with feeding, play, and persistent progression."
     },
     {
       "goal_zh": "把其他工具的历史会话搬进 DSH",
       "goal_en": "Migrate chat histories from other tools into DSH",
-      "repos": ["Nwflower/dsh-chat-import"],
+      "repos": [
+        "Nwflower/dsh-chat-import"
+      ],
       "why_zh": "全保真导入 Claude Code / Codex / ChatGPT / Cursor 的聊天记录（含工具调用/思考块），导入后可直接续聊。",
       "why_en": "Full-fidelity import of Claude Code / Codex / ChatGPT / Cursor transcripts (tools + thinking) as resumable DSH sessions."
     },
     {
       "goal_zh": "换皮肤、自定义背景",
       "goal_en": "Change the skin / set a custom wallpaper",
-      "repos": ["KinGao294/dsh-skin"],
+      "repos": [
+        "KinGao294/dsh-skin",
+        "wanzhiwei5/dsh-skin-amis"
+      ],
       "why_zh": "内置多套 --dsw-alias-* 配色一键切换，半透明壁纸支持透明度与模糊调节（Codex 风格）。",
       "why_en": "One-click --dsw-alias-* palette switching plus a translucent wallpaper with opacity and blur controls (Codex-style)."
     },
     {
       "goal_zh": "查看 Token 用量与费用",
       "goal_en": "Track token usage and costs",
-      "repos": ["bpc-oss/dsh-web-billing", "Han-1413141/dsh-cost-meter"],
+      "repos": [
+        "bpc-oss/dsh-web-billing",
+        "Han-1413141/dsh-cost-meter"
+      ],
       "why_zh": "按官方政策自动计价（含峰谷时段），逐条消息记账，显示账号余额；界面语言自动切换人民币/美元。",
       "why_en": "Auto-bill per message with official pricing (incl. peak/off-peak hours), keep a persistent cost ledger, show the account balance, and switch ¥/$ with the UI language."
     },
     {
       "goal_zh": "让外部 Agent 驱动 Harness 执行任务",
       "goal_en": "Drive Harness from an external agent",
-      "repos": ["chushixixin/dsh-harness-mcp-server"],
+      "repos": [
+        "chushixixin/dsh-harness-mcp-server"
+      ],
       "why_zh": "在 Harness 内部启动 MCP server，让任意 MCP 客户端（如 Hermes）下发任务给 Harness 执行，实现「大脑 + 胳膊」协作。",
       "why_en": "Runs an MCP server inside Harness so any MCP client (e.g. Hermes) can delegate coding tasks to Harness — a 'brain + arms' setup."
     },
     {
       "goal_zh": "从外部设备安全访问本机 Harness",
       "goal_en": "Access your local Harness securely from another device",
-      "repos": ["flymysql/dsh-remote"],
+      "repos": [
+        "flymysql/dsh-remote"
+      ],
       "why_zh": "打印当前实例的精确连接命令：SSH 本地转发、autossh 保活、反向隧道（NAT 友好）与带 --trusted-host 的反向代理，设置页一键复制；遵循官方安全设计，不碰 0.0.0.0。",
       "why_en": "Prints the exact commands for the live instance — SSH local forward, autossh keepalive, NAT-friendly reverse tunnel, and reverse-proxy access with --trusted-host — with one-click copy from the settings page. Respects the official safety design: no 0.0.0.0 hacks."
     }
@@ -144,21 +183,32 @@
       "title_en": "Everyday experience kit",
       "summary_zh": "先解决插件管理、后台状态和长对话导航这三个最常见的问题。",
       "summary_en": "Start with plugin management, background-task visibility, and long-conversation navigation.",
-      "repos": ["vlln/plugin-registry", "vlln/dsh-task-status", "vlln/dsh-navbar"]
+      "repos": [
+        "vlln/plugin-registry",
+        "vlln/dsh-task-status",
+        "vlln/dsh-navbar"
+      ]
     },
     {
       "title_zh": "自动化套装",
       "title_en": "Automation kit",
       "summary_zh": "同时拥有定时循环和事件驱动唤醒，适合长时间、无人值守任务。",
       "summary_en": "Combine scheduled loops with event-driven wakeups for long-running or unattended work.",
-      "repos": ["vlln/dsh-loop", "fuhefei/dsh-sentinel"]
+      "repos": [
+        "vlln/dsh-loop",
+        "fuhefei/dsh-sentinel"
+      ]
     },
     {
       "title_zh": "创作与界面套装",
       "title_en": "Creation and interface kit",
       "summary_zh": "让 Agent 生成交互式 UI、操作真实设计画布，并理解视觉内容。",
       "summary_en": "Let agents render interactive UI, operate a real design canvas, and understand visual content.",
-      "repos": ["omdsh-dev/dsh-genui", "ZSeven-W/dsh-openpencil", "Anionex/dsh-vision-toolkit"]
+      "repos": [
+        "omdsh-dev/dsh-genui",
+        "ZSeven-W/dsh-openpencil",
+        "Anionex/dsh-vision-toolkit"
+      ]
     }
   ],
   "editor_picks": [
@@ -168,8 +218,16 @@
       "title_en": "dsh-desktop — a standalone desktop client for DSH",
       "summary_zh": "社区维护的非官方桌面客户端，直接加载官方 Web UI：自动复用本机已运行的实例，也可用安装包内置的 dsh 运行时一键启动，无需额外安装 Node.js 或 CLI；支持智能连接、远程实例连接、托盘常驻和异常恢复。",
       "summary_en": "A community-maintained unofficial desktop client that loads DSH's official Web UI directly — auto-reuse a running local instance, or launch the bundled dsh runtime with no Node.js/CLI install required. Includes smart connect, remote-instance support, tray residency, and crash recovery.",
-      "labels_zh": ["桌面客户端", "开箱即用", "智能连接"],
-      "labels_en": ["desktop client", "zero-install", "smart connect"]
+      "labels_zh": [
+        "桌面客户端",
+        "开箱即用",
+        "智能连接"
+      ],
+      "labels_en": [
+        "desktop client",
+        "zero-install",
+        "smart connect"
+      ]
     },
     {
       "repo": "vlln/plugin-registry",
@@ -177,8 +235,16 @@
       "title_en": "plugin-registry — move from browsing to managing plugins",
       "summary_zh": "面向普通用户的可视化插件管理入口，同时给开发者提供 make-dsh-plugin 引导。适合第一次进入 DSH 插件生态的人。",
       "summary_en": "A visual plugin-management entry point for users, paired with make-dsh-plugin guidance for developers. A strong first stop for the ecosystem.",
-      "labels_zh": ["新手友好", "插件管理", "开发引导"],
-      "labels_en": ["beginner-friendly", "plugin management", "developer guidance"]
+      "labels_zh": [
+        "新手友好",
+        "插件管理",
+        "开发引导"
+      ],
+      "labels_en": [
+        "beginner-friendly",
+        "plugin management",
+        "developer guidance"
+      ]
     },
     {
       "repo": "fuhefei/dsh-sentinel",
@@ -186,8 +252,16 @@
       "title_en": "dsh-sentinel — event-driven wakeups beyond schedules",
       "summary_zh": "监听文件、命令、HTTP、进程或 Webhook，在条件满足时唤醒 DSH。适合自动化监控、长任务和无人值守工作流。",
       "summary_en": "Watch files, commands, HTTP endpoints, processes, or webhooks and wake DSH when conditions match. Built for monitoring and unattended workflows.",
-      "labels_zh": ["事件驱动", "持久监控", "自动化"],
-      "labels_en": ["event-driven", "durable watches", "automation"]
+      "labels_zh": [
+        "事件驱动",
+        "持久监控",
+        "自动化"
+      ],
+      "labels_en": [
+        "event-driven",
+        "durable watches",
+        "automation"
+      ]
     },
     {
       "repo": "vlln/dsh-task-status",
@@ -195,8 +269,16 @@
       "title_en": "dsh-task-status — see what background work is doing",
       "summary_zh": "把后台任务进度和实时输出 tail 放回对话页面，尤其适合构建、下载、测试等长时间命令。",
       "summary_en": "Bring background-task progress and a live output tail into the conversation view, especially for builds, downloads, and long-running tests.",
-      "labels_zh": ["后台任务", "实时输出", "可观察性"],
-      "labels_en": ["background tasks", "live output", "observability"]
+      "labels_zh": [
+        "后台任务",
+        "实时输出",
+        "可观察性"
+      ],
+      "labels_en": [
+        "background tasks",
+        "live output",
+        "observability"
+      ]
     },
     {
       "repo": "omdsh-dev/dsh-annotation",
@@ -204,8 +286,16 @@
       "title_en": "dsh-annotation — Codex-style annotations for DSH",
       "summary_zh": "选中文字、添加批注并随消息发送，回复可以逐条对照 Annotation，适合审稿、代码评审和精确反馈。",
       "summary_en": "Select text, attach annotations to the next message, and receive annotation-aware replies. Useful for review and precise feedback.",
-      "labels_zh": ["批注", "精确反馈", "零核心改动"],
-      "labels_en": ["annotations", "precise feedback", "zero core changes"]
+      "labels_zh": [
+        "批注",
+        "精确反馈",
+        "零核心改动"
+      ],
+      "labels_en": [
+        "annotations",
+        "precise feedback",
+        "zero core changes"
+      ]
     },
     {
       "repo": "omdsh-dev/dsh-genui",
@@ -213,8 +303,16 @@
       "title_en": "dsh-genui — turn replies into interactive interfaces",
       "summary_zh": "在对话中直接呈现图表、表单、测验、Mermaid、3D 场景，并把用户操作重新送回模型。",
       "summary_en": "Render charts, forms, quizzes, Mermaid diagrams, and 3D scenes inline, with user actions flowing back to the model.",
-      "labels_zh": ["生成式 UI", "交互", "可视化"],
-      "labels_en": ["generative UI", "interactive", "visualization"]
+      "labels_zh": [
+        "生成式 UI",
+        "交互",
+        "可视化"
+      ],
+      "labels_en": [
+        "generative UI",
+        "interactive",
+        "visualization"
+      ]
     },
     {
       "repo": "ZSeven-W/dsh-openpencil",
@@ -222,8 +320,16 @@
       "title_en": "DSH OpenPencil — let agents work on a real design canvas",
       "summary_zh": "连接 DSH 与 OpenPencil，让 Agent 理解画布结构、节点和组件关系，直接创建、修改、预览并验证可编辑的多页面设计，而不是只返回一张图片。",
       "summary_en": "Connect DSH to OpenPencil so agents can understand canvas structure and directly create, edit, preview, and validate editable multi-page designs instead of returning a flat image.",
-      "labels_zh": ["设计画布", "多页面", "可编辑"],
-      "labels_en": ["design canvas", "multi-page", "editable"]
+      "labels_zh": [
+        "设计画布",
+        "多页面",
+        "可编辑"
+      ],
+      "labels_en": [
+        "design canvas",
+        "multi-page",
+        "editable"
+      ]
     },
     {
       "repo": "Anionex/dsh-vision-toolkit",
@@ -231,8 +337,16 @@
       "title_en": "dsh-vision-toolkit — a vision toolbox for text-first models",
       "summary_zh": "覆盖图片问答、长截图 OCR、UI 还原、视觉定位、像素对比和 Artifacts，适合前端与视觉任务。",
       "summary_en": "Cover image Q&A, long-screenshot OCR, UI restoration, grounding, pixel diffs, and artifacts for frontend and visual work.",
-      "labels_zh": ["视觉理解", "OCR", "UI 还原"],
-      "labels_en": ["vision", "OCR", "UI restoration"]
+      "labels_zh": [
+        "视觉理解",
+        "OCR",
+        "UI 还原"
+      ],
+      "labels_en": [
+        "vision",
+        "OCR",
+        "UI restoration"
+      ]
     },
     {
       "repo": "vlln/whale-girl",
@@ -240,8 +354,16 @@
       "title_en": "whale-girl — a companion for vibe coding",
       "summary_zh": "可拖拽、投喂和玩耍的 DSH Web GUI 桌面宠物，为长时间 Agent 工作增加一点陪伴感。",
       "summary_en": "A draggable DSH Web GUI companion with feeding and play interactions for a little personality during long agent sessions.",
-      "labels_zh": ["桌面宠物", "陪伴", "Web UI"],
-      "labels_en": ["desktop pet", "companion", "Web UI"]
+      "labels_zh": [
+        "桌面宠物",
+        "陪伴",
+        "Web UI"
+      ],
+      "labels_en": [
+        "desktop pet",
+        "companion",
+        "Web UI"
+      ]
     },
     {
       "repo": "modusensus/dsh-mneme",
@@ -249,8 +371,16 @@
       "title_en": "dsh-mneme — memory sovereignty: human-editable cross-session memory",
       "summary_zh": "SQLite + 可人工编辑的 Markdown 镜像，记忆不再黑盒；autoDream 后台自动去重/合并/裁决，越用越精炼。106 个测试护航，记忆这回事不该让 agent 一个人说了算。",
       "summary_en": "SQLite + human-editable Markdown mirror keeps memory transparent — you hold the memory, not the agent. autoDream consolidates in the background; 106 tests back it up.",
-      "labels_zh": ["记忆主权", "跨会话记忆", "autoDream"],
-      "labels_en": ["memory sovereignty", "cross-session", "autoDream"]
+      "labels_zh": [
+        "记忆主权",
+        "跨会话记忆",
+        "autoDream"
+      ],
+      "labels_en": [
+        "memory sovereignty",
+        "cross-session",
+        "autoDream"
+      ]
     },
     {
       "repo": "ccch1mneyyy/dsh-TUI",
@@ -258,8 +388,16 @@
       "title_en": "dsh-TUI — a full-screen terminal UI for DSH",
       "summary_zh": "Claude Code 风格的全屏交互终端插件：像素鲸鱼顶栏、实时工作状态行、思考流式展开、双击 Esc 回滚、上下文进度条与 TPS 仪表，npm 一键安装，为偏爱 CLI 的用户补上 DSH 官方尚缺的 TUI 体验。",
       "summary_en": "A Claude Code-style full-screen terminal UI for DSH — pixel-whale header, a live status line, streaming thought expansion, double-Esc rollback, and a context/TPS gauge. One-command npm install, filling the TUI gap for CLI-first users.",
-      "labels_zh": ["终端 TUI", "全屏交互", "CLI 优先"],
-      "labels_en": ["terminal UI", "full-screen", "CLI-first"]
+      "labels_zh": [
+        "终端 TUI",
+        "全屏交互",
+        "CLI 优先"
+      ],
+      "labels_en": [
+        "terminal UI",
+        "full-screen",
+        "CLI-first"
+      ]
     },
     {
       "repo": "zhu1090093659/dsh-web-ui",
@@ -267,8 +405,16 @@
       "title_en": "dsh-web-ui — a plugin and skin bundle for the DSH Web UI",
       "summary_zh": "一站式功能合集：任务看板、Git 关系图、侧边面板、远程移动端界面、桌面宠物、实时 Token 用量统计与皮肤中心，一次安装覆盖多个常见的界面与体验诉求。",
       "summary_en": "An all-in-one bundle for the DSH Web UI — task board, git graph, a side panel, a remote mobile UI, a desktop pet, live token stats, and a skin center — covering several common UI needs in a single install.",
-      "labels_zh": ["功能合集", "皮肤中心", "移动端"],
-      "labels_en": ["all-in-one", "skin center", "mobile UI"]
+      "labels_zh": [
+        "功能合集",
+        "皮肤中心",
+        "移动端"
+      ],
+      "labels_en": [
+        "all-in-one",
+        "skin center",
+        "mobile UI"
+      ]
     },
     {
       "repo": "HsiangNianian/dsh-auto-continue",
@@ -276,8 +422,33 @@
       "title_en": "dsh-auto-continue — auto-resume interrupted requests",
       "summary_zh": "网络波动、超时或宿主崩溃导致回合失败后，自动向会话发送「继续」续跑：错误分类（认证/余额等永久性错误跳过）、自适应退避、模板化继续文本与浏览器通知，全部可在插件设置卡片中调整，无人值守也能自己爬起来。",
       "summary_en": "Auto-resumes turns that failed to network hiccups, timeouts, or host crashes by sending a queued \"继续\": error classification skips permanent failures, adaptive backoff spaces out retries, continue text supports templates, and browser notifications keep you informed — all configurable from the plugin settings card.",
-      "labels_zh": ["自动续跑", "无人值守", "错误分类"],
-      "labels_en": ["auto-resume", "unattended", "error classification"]
+      "labels_zh": [
+        "自动续跑",
+        "无人值守",
+        "错误分类"
+      ],
+      "labels_en": [
+        "auto-resume",
+        "unattended",
+        "error classification"
+      ]
+    },
+    {
+      "repo": "wanzhiwei5/dsh-skin-amis",
+      "title_zh": "dsh-skin-amis — 鸣潮爱弥斯粉白主题皮肤",
+      "title_en": "dsh-skin-amis — a Wuthering Waves Amis pink-white skin",
+      "summary_zh": "以鸣潮角色爱弥斯（粉发机娘）为灵感的粉白主题皮肤：樱花粉与纯白渐变、赛博霓虹深色模式、内置角色背景图、半透明毛玻璃面板、按钮粉光与圆角细节，双主题一键切换。",
+      "summary_en": "A Wuthering Waves Amis-inspired pink-white skin for the DSH Web UI: sakura-pink to white gradients, a cyber-neon dark mode, a bundled character wallpaper, translucent glass panels, pink glow buttons and rounded details — with light and dark themes.",
+      "labels_zh": [
+        "主题皮肤",
+        "粉白配色",
+        "角色壁纸"
+      ],
+      "labels_en": [
+        "skin",
+        "pink-white",
+        "character wallpaper"
+      ]
     }
-]
+  ]
 }


### PR DESCRIPTION
## 添加内容 / What's added

将 **dsh-skin-amis**（鸣潮爱弥斯粉白主题皮肤）收录到列表：

- **scenarios**「换皮肤、自定义背景」新增仓库 wanzhiwei5/dsh-skin-amis
- **editor_picks** 新增推荐条目

## 插件简介 / About

以鸣潮角色爱弥斯（粉发机娘）为灵感的 DSH Web GUI 主题皮肤：樱花粉+纯白渐变、赛博霓虹深色模式、内置角色背景图、半透明毛玻璃面板、按钮粉光圆角细节，浅色/深色双主题。

A Wuthering Waves Amis-inspired pink-white skin for DSH Web UI with bundled character wallpaper, light/dark themes, and translucent panels.

## 收录条件 / Criteria

- [x] 仓库公开，已设置 \dsh-plugin\ Topic
- [x] 已设置 GitHub 项目简介（description）
- [x] 可安装的 DSH 插件（bundle 声明完整）
- [x] 仅修改 \data/curated.json\，未提交生成文件