### PR TITLE
curate: add dsh-vision-proxy to the visual understanding scenario

### DIFF
--- a/data/curated.json
+++ b/data/curated.json
@@ -188,9 +188,9 @@
     {
       "goal_zh": "给 DSH 增加视觉理解能力",
       "goal_en": "Add visual understanding to DSH",
-      "repos": ["liustack/modlens", "Anionex/dsh-vision-toolkit", "ycp424c/dsh-luna-vision-bridge"],
-      "why_zh": "modlens 把图片转成 OCR/布局/语义结构化证据；dsh-vision-toolkit 覆盖图片问答、长截图 OCR、UI 还原与像素对比；纯文本模型也可经 Luna 转写桥接继续处理图片。",
-      "why_en": "modlens turns images into structured OCR/layout/semantics evidence; dsh-vision-toolkit covers image Q&A, long-screenshot OCR, UI restoration, and pixel diffs — or bridge pure-text models to image input via a Luna transcription adapter."
+      "repos": ["liustack/modlens", "Anionex/dsh-vision-toolkit", "ycp424c/dsh-luna-vision-bridge", "Flyvhidbwo/dsh-vision-proxy"],
+      "why_zh": "modlens 把图片转成 OCR/布局/语义结构化证据；dsh-vision-toolkit 覆盖图片问答、长截图 OCR、UI 还原与像素对比；纯文本模型也可经 Luna 转写桥接继续处理图片。dsh-vision-proxy 则保持 DeepSeek 大脑，把附加图片自动经任意 OpenAI 兼容 VLM 转译成文字（默认免费匿名端点，零配置）。",
+      "why_en": "modlens turns images into structured OCR/layout/semantics evidence; dsh-vision-toolkit covers image Q&A, long-screenshot OCR, UI restoration, and pixel diffs — or bridge pure-text models to image input via a Luna transcription adapter. dsh-vision-proxy keeps DeepSeek the brain and auto-transcribes attached images via any OpenAI-compatible VLM (free anonymous endpoint by default)."
     },
     {
       "goal_zh": "让 Agent 自己搜索网页和 X，答案带引用",

--- a/data/curated.json
+++ b/data/curated.json
@@ -190,7 +190,7 @@
       "goal_en": "Add visual understanding to DSH",
       "repos": ["liustack/modlens", "Anionex/dsh-vision-toolkit", "ycp424c/dsh-luna-vision-bridge", "Flyvhidbwo/dsh-vision-proxy"],
       "why_zh": "modlens 把图片转成 OCR/布局/语义结构化证据；dsh-vision-toolkit 覆盖图片问答、长截图 OCR、UI 还原与像素对比；纯文本模型也可经 Luna 转写桥接继续处理图片。dsh-vision-proxy 则保持 DeepSeek 大脑，把附加图片自动经任意 OpenAI 兼容 VLM 转译成文字（默认免费匿名端点，零配置）。",
-      "why_en": "modlens turns images into structured OCR/layout/semantics evidence; dsh-vision-toolkit covers image Q&A, long-screenshot OCR, UI restoration, and pixel diffs — or bridge pure-text models to image input via a Luna transcription adapter. dsh-vision-proxy keeps DeepSeek the brain and auto-transcribes attached images via any OpenAI-compatible VLM (free anonymous endpoint by default)."
+      "why_en": "modlens turns images into structured OCR/layout/semantics evidence; dsh-vision-toolkit covers image Q&A, long-screenshot OCR, UI restoration, and pixel diffs — or bridge pure-text models to image input via a Luna transcription adapter. dsh-vision-proxy keeps DeepSeek the brain and auto-transcribes attached images via any OpenAI-compatible VLM — a keyed fast path (qwen3.7-flash), or local Ollama auto-detected with zero config."
     },
     {
       "goal_zh": "让 Agent 自己搜索网页和 X，答案带引用",

--- a/data/curated.json
+++ b/data/curated.json
@@ -190,7 +190,7 @@
       "goal_en": "Add visual understanding to DSH",
       "repos": ["liustack/modlens", "Anionex/dsh-vision-toolkit", "ycp424c/dsh-luna-vision-bridge", "Flyvhidbwo/dsh-vision-proxy"],
       "why_zh": "modlens 把图片转成 OCR/布局/语义结构化证据；dsh-vision-toolkit 覆盖图片问答、长截图 OCR、UI 还原与像素对比；纯文本模型也可经 Luna 转写桥接继续处理图片。dsh-vision-proxy 则保持 DeepSeek 大脑，把附加图片自动经任意 OpenAI 兼容 VLM 转译成文字（默认免费匿名端点，零配置）。",
-      "why_en": "modlens turns images into structured OCR/layout/semantics evidence; dsh-vision-toolkit covers image Q&A, long-screenshot OCR, UI restoration, and pixel diffs — or bridge pure-text models to image input via a Luna transcription adapter. dsh-vision-proxy keeps DeepSeek the brain and auto-transcribes attached images via any OpenAI-compatible VLM — a keyed fast path (qwen3.7-flash), or local Ollama auto-detected with zero config."
+      "why_en": "modlens turns images into structured OCR/layout/semantics evidence; dsh-vision-toolkit covers image Q&A, long-screenshot OCR, UI restoration, and pixel diffs — or bridge pure-text models to image input via a Luna transcription adapter. dsh-vision-proxy keeps DeepSeek the brain and auto-transcribes attached images via any OpenAI-compatible VLM — a keyed fast path (default qwen3.7-flash; DashScope/Zhipu/OpenRouter or any OpenAI-compatible endpoint), or local Ollama auto-detected with zero config."
     },
     {
       "goal_zh": "让 Agent 自己搜索网页和 X，答案带引用",


### PR DESCRIPTION
## 说明

在"Add visual understanding to DSH / 给 DSH 增加视觉理解能力"场景中新增 [dsh-vision-proxy](https://github.com/Flyvhidbwo/dsh-vision-proxy)：

- DeepSeek 大脑 + 自动识图：GUI 附加图片自动经 OpenAI 兼容 VLM 转译成文字后交给 DeepSeek 作答
- 无 key 自动探测本地 Ollama（零配置），有 key 走快速通道（默认 qwen3.7-flash）
- 已打 dsh-plugin topic、有仓库描述、公开、MIT 许可，满足收录标准
- 已通过本地 node scripts/validate-curated.mjs 校验