### PR TITLE
curate: add dsh-memory-gate (记忆闸门) editor pick

### DIFF
--- a/data/curated.json
+++ b/data/curated.json
@@ -501,6 +501,15 @@
       "summary_en": "Auto-resumes turns that failed to network hiccups, timeouts, or host crashes by sending a queued \"继续\": error classification skips permanent failures, adaptive backoff spaces out retries, continue text supports templates, and browser notifications keep you informed — all configurable from the plugin settings card.",
       "labels_zh": ["自动续跑", "无人值守", "错误分类"],
       "labels_en": ["auto-resume", "unattended", "error classification"]
+    },
+    {
+      "repo": "GIT121995/dsh-memory-gate",
+      "title_zh": "dsh-memory-gate — 检索到≠注入：带权威门控的本地长期记忆",
+      "title_en": "dsh-memory-gate — retrieved ≠ injected: authority-gated local long-term memory",
+      "summary_zh": "纯本地 SQLite + FTS5 长期记忆：每条记忆须通过 CBDC（Claim→Belief→Decision→Consumption）四段权威门控才会进入上下文，输出 use/verify/ignore 可解释决策并保留完整检索/注入审计；shadow/assist/enforce 三种模式，默认每次最多注入 3 条、1200 字符，不增加第二次模型调用。",
+      "summary_en": "Local SQLite + FTS5 long-term memory: every memory must pass CBDC (Claim→Belief→Decision→Consumption) authority gating before entering context, with explainable use/verify/ignore decisions and a full retrieval/injection audit trail; shadow/assist/enforce modes, default injection capped at 3 claims / 1200 characters, no extra model call.",
+      "labels_zh": ["记忆闸门", "可审计", "零额外调用"],
+      "labels_en": ["memory gate", "auditable", "no extra call"]
     }
   ]
 }


### PR DESCRIPTION
推荐收录 **dsh-memory-gate（记忆闸门）** — CBDC 权威门控的本地长期记忆插件（npm: `dsh-memory-gate`，MIT，v0.2.0，目标 Harness 0.1.0-rc.6）。

推荐理由（中英双语）：

- **定位差异化**：生态里多数记忆插件解决"记什么/怎么检索"，本插件解决"检索到≠注入"——每条记忆须通过 CBDC（Claim→Belief→Decision→Consumption）四段权威门控，输出可解释的 use/verify/ignore 决策与完整检索/注入审计，恰好补上记忆类目"可审计门控"的空位。
- **克制且有界**：默认每次最多注入 3 条、1200 字符，不增加第二次模型调用；SQLite + FTS5 纯本地，无 embedding 依赖；API Key/Token/密码样式内容落库前拒绝。
- **安装即用**：`dsh plugin --profile web add dsh-memory-gate`，自带 `/memory` 管理命令（status/list/remember/search/explain/feedback/forget/mode），shadow/assist/enforce 三档模式。

仓库已带 `dsh-plugin` topic 并公开，预计也会在下次目录刷新时自动进入 CATALOG。

本次 PR 仅修改 `data/curated.json`，已本地通过 `node scripts/validate-curated.mjs`。