### PR TITLE
docs: add Ceelog/dsh-plugins to author showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -211,6 +211,7 @@ mindmap
 - **[dsh-lark-meeting-notifier](https://github.com/yeruizhi/dsh-lark-meeting-notifier)**（[@yeruizhi](https://github.com/yeruizhi) · 2026-08-14）— 飞书会议提醒悬浮框：展示今日/明日会议、多闹钟闪烁提醒，在你跟 AI 聊得忘我时提醒「该去跟碳基生命开会了」。
 - **[dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill)**（[@dhicoc](https://github.com/dhicoc) · 2026-08-14）— 85 个 SKILL.md 组成的逆向工程、授权渗透测试与安全研究技能包，安装后按任务自动路由对应技能。
 - **[dsh-vision-router](https://github.com/ysr666/dsh-vision-router)**（[@ysr666](https://github.com/ysr666) · 2026-08-14）— 给纯文本 DSH Agent 装上眼睛：内置免 key 视觉链路（匿名端点）+ 像素级工具集（问答/定位/裁剪/像素对比/取色/OCR/SVG 描摹/抠图/截图），无需 Python，一条命令安装，图片回合像普通工具调用回合一样工作。注意：默认匿名端点会把图片发往第三方，介意隐私请自行配置端点。
+- **[dsh-plugins](https://github.com/Ceelog/dsh-plugins)**（[@Ceelog](https://github.com/Ceelog) · 2026-08-15）— 两款 DSH Web 插件：按项目定时运行提示词并保留持久化历史；在设置面板中添加、编辑、删除和启停 MCP 服务器，保存后热重载。
 
 ## 🔍 我们如何维护这个列表
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -211,6 +211,7 @@ Self-submitted recommendations from plugin authors, following the [contributing 
 - **[dsh-lark-meeting-notifier](https://github.com/yeruizhi/dsh-lark-meeting-notifier)** ([@yeruizhi](https://github.com/yeruizhi) · 2026-08-14) — A Feishu/Lark meeting-reminder panel: today's and tomorrow's meetings with flashing alarms, nudging you when it's time to "go meet carbon-based lifeforms".
 - **[dsh-reverse-skill](https://github.com/dhicoc/dsh-reverse-skill)** ([@dhicoc](https://github.com/dhicoc) · 2026-08-14) — A pack of 85 SKILL.md files covering reverse engineering, authorized pentesting, and security research, routed on demand.
 - **[dsh-vision-router](https://github.com/ysr666/dsh-vision-router)** ([@ysr666](https://github.com/ysr666) · 2026-08-14) — Eyes for text-only DSH agents: a built-in keyless vision chain plus pixel-level tools (Q&A, grounding, crop, pixel diff, colors, OCR, SVG trace, cutout, screenshots) — no Python, one-command install, and image turns behave like ordinary tool-calling turns. Note: the default anonymous endpoint sends images to a third party — configure your own endpoint if that matters to you.
+- **[dsh-plugins](https://github.com/Ceelog/dsh-plugins)** ([@Ceelog](https://github.com/Ceelog) · 2026-08-15) — Two DSH Web plugins: run per-project prompts on schedules with durable history; add, edit, remove and enable or disable MCP servers from Settings, with hot reload on save.
 
 ## 🔍 How this list is maintained
 


### PR DESCRIPTION
## Self-recommendation / 自荐说明

`Ceelog/dsh-plugins` contains two installable DSH Web plugins for users who want unattended project automation or visual MCP configuration:

- `@opendsh/dsh-plugin-scheduled-tasks` runs project prompts in fresh headless sessions on one-time, interval, or cron schedules and keeps durable run history.
- `@opendsh/dsh-plugin-setting-mcp` lets users add, edit, remove, enable, and disable MCP servers from Settings, with hot reload on save.

The PR appends one repository entry to the Chinese and English Author showcase sections, following the one-repository-per-PR rule. No generated files are included.

Validation: `node scripts/validate-curated.mjs` and `node scripts/update.mjs --from-snapshot`.