### PR TITLE
需求表新增：把 Claude Code 的整套配置搬进 DSH

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,7 @@ mindmap
 | 回合结束时收到桌面通知 | [dsh-notification](https://github.com/omdsh-dev/dsh-notification) | 按结果类型（成功/失败）控制通知，支持关键词过滤，长时间任务无需盯屏。 |
 | 回退对话与工作区状态 | [dsh-turn-rewind](https://github.com/Anionex/dsh-turn-rewind) | 基于持久化 Change Ledger 回退到任意早期回合，对话与代码状态一起恢复。 |
 | 给工作区增加一个陪伴型宠物 | [whale-girl](https://github.com/vlln/whale-girl) | 可拖拽、投喂和玩耍的积累型鲸鱼娘桌面伙伴。 |
+| 把 Claude Code 的整套配置搬进 DSH | [dsh-movein](https://github.com/sjh9714/dsh-movein) | 一条命令搬完技能、MCP、hooks、子代理、权限规则，默认先出搬家清单预演，权限规则带迁移差异报告。CLAUDE.md 不用搬，DSH 原生就读。 |
 | 把其他工具的历史会话搬进 DSH | [dsh-chat-import](https://github.com/Nwflower/dsh-chat-import) | 13 源全保真导入（Claude Code/Codex/ChatGPT/Cursor/Gemini/Reasonix/opencode/ZCode/Grok Build/OpenClaw/Pi/Hermes/Kimi）历史会话为可续聊 DSH 会话，并支持反向导出/同步回 Claude Code。 |
 | 换皮肤、自定义背景 | [dsh-skin](https://github.com/KinGao294/dsh-skin) · [dsh-deep-whale](https://github.com/Small-tailqwq/dsh-deep-whale) | dsh-skin 一键切换多套 --dsw-alias-* 配色并支持半透明壁纸（Codex 风格）；dsh-deep-whale 是生态内最受欢迎的鲸鱼娘皮肤系列（CC BY-NC-SA，不可商用）。 |
 | 查看 Token 用量与费用 | [dsh-web-billing](https://github.com/bpc-oss/dsh-web-billing) · [dsh-cost-meter](https://github.com/Han-1413141/dsh-cost-meter) | 按官方政策自动计价（含峰谷时段），逐条消息记账，显示账号余额；界面语言自动切换人民币/美元。 |


### PR DESCRIPTION
在「我想让 DSH 做什么」表中补一行，紧挨会话迁移（dsh-chat-import 管历史会话，dsh-movein 管配置本身，两者互补）。一条命令搬技能、MCP、hooks、子代理、权限规则，默认 dry run，权限规则输出迁移差异报告。已收录于 awesome-dsh-plugin 与 0xsline/awesome-deepseek-harness。npm: dsh-movein