### PR TITLE
Add dsh-lsp-actions to the author showcase

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ mindmap
 
 - **[dsh-tray](https://github.com/KAIbsb/dsh-tray)**（[@KAIbsb](https://github.com/KAIbsb) · 2026-08-15）— Windows 托盘管家:一键启动/重启/停止 DSH Web、崩溃自动拉起、状态鲸鱼图标与开机自启,配合浏览器 APP 模式窗口更顺手。
 - **[dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide)**（[@PerryLink](https://github.com/PerryLink) · 2026-08-15）— DSH 插件开发知识库：官方约束、任务工作流、API 参考与社区踩坑，作为按需加载的智能体技能随 bundle 安装，开发插件时让 DSH 自己查。
+- **[dsh-lsp-actions](https://github.com/PerryLink/dsh-lsp-actions)**（[@PerryLink](https://github.com/PerryLink) · 2026-08-15）— DeepSeek Harness 的 LSP 动作面：诊断、格式化、补全、代码动作、符号、签名提示、inlay 提示与重命名 8 个工具，由真实语言服务器驱动；写入走 write-intent 与沙箱策略，其余只读。
 ## 🔍 我们如何维护这个列表
 
 - **面向使用者，而不是爬虫：** 从「我想完成什么」出发组织首页，而不是让你阅读几百行仓库名称。

--- a/README_EN.md
+++ b/README_EN.md
@@ -231,6 +231,7 @@ Self-submitted recommendations from plugin authors, following the [contributing 
 
 - **[dsh-tray](https://github.com/KAIbsb/dsh-tray)** ([@KAIbsb](https://github.com/KAIbsb) · 2026-08-15) — A Windows tray manager for DSH Web: one-click start/restart/stop, crash auto-restart, whale status icon, and autostart — pairs nicely with a browser app-mode window.
 - **[dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide)** ([@PerryLink](https://github.com/PerryLink) · 2026-08-15) — The DSH plugin-development knowledge base as an on-demand agent skill: official constraints, task workflows, API references, and community pitfalls, installed as a bundle.
+- **[dsh-lsp-actions](https://github.com/PerryLink/dsh-lsp-actions)** ([@PerryLink](https://github.com/PerryLink) · 2026-08-15) — The LSP action surface for DeepSeek Harness: diagnostics, formatting, completion, code actions, symbols, signature help, inlay hints, and rename tools backed by real language servers; writes go through write-intent and the sandbox policy, everything else is read-only.
 ## 🔍 How this list is maintained
 
 - **Built for users, not crawlers:** the front page is organized around "what I want to get done", not hundreds of repo names.


### PR DESCRIPTION
自荐说明 / Self-recommendation：解决「agent 写代码时缺乏编译器级反馈」的问题——把语言服务器的诊断、格式化、补全、代码动作、符号、签名提示、inlay 提示与重命名作为 8 个工具接入 DSH，适合需要真实工程反馈闭环的编码 agent。

- 仓库公开、带 dsh-plugin Topic、已填写简介、是可安装的 DSH 插件（dsh.bundle manifest + npm 包 dsh-lsp-actions@0.2.0）。
- 中英自荐区各追加一行，未动其他内容、未提交生成文件。
- 本地自检 
ode scripts/validate-curated.mjs（GITHUB_TOKEN 认证）通过：13 category overrides and 28 showcase repositories checked against the GitHub API。