### PR TITLE
docs: add dsh-doc-share to author showcase（自荐 dsh-doc-share）

### DIFF
--- a/README.md
+++ b/README.md
@@ -231,6 +231,7 @@ mindmap
 
 - **[dsh-tray](https://github.com/KAIbsb/dsh-tray)**（[@KAIbsb](https://github.com/KAIbsb) · 2026-08-15）— Windows 托盘管家:一键启动/重启/停止 DSH Web、崩溃自动拉起、状态鲸鱼图标与开机自启,配合浏览器 APP 模式窗口更顺手。
 - **[dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide)**（[@PerryLink](https://github.com/PerryLink) · 2026-08-15）— DSH 插件开发知识库：官方约束、任务工作流、API 参考与社区踩坑，作为按需加载的智能体技能随 bundle 安装，开发插件时让 DSH 自己查。
+- **[dsh-doc-share](https://github.com/dawsondx/dsh-doc-share)**（[@dawsondx](https://github.com/dawsondx) · 2026-08-15）— 把 DSH 对话重排成带封面、摘要统计与章节排版的正式报告：轮次选择弹窗（搜索/全选/加载更早历史）、单轮快捷分享、兼容 gen-UI 富组件，一次生成 PNG / 单 HTML / PDF / Markdown 四种格式。
 ## 🔍 我们如何维护这个列表
 
 - **面向使用者，而不是爬虫：** 从「我想完成什么」出发组织首页，而不是让你阅读几百行仓库名称。

--- a/README_EN.md
+++ b/README_EN.md
@@ -231,6 +231,7 @@ Self-submitted recommendations from plugin authors, following the [contributing 
 
 - **[dsh-tray](https://github.com/KAIbsb/dsh-tray)** ([@KAIbsb](https://github.com/KAIbsb) · 2026-08-15) — A Windows tray manager for DSH Web: one-click start/restart/stop, crash auto-restart, whale status icon, and autostart — pairs nicely with a browser app-mode window.
 - **[dsh-plugin-guide](https://github.com/PerryLink/dsh-plugin-guide)** ([@PerryLink](https://github.com/PerryLink) · 2026-08-15) — The DSH plugin-development knowledge base as an on-demand agent skill: official constraints, task workflows, API references, and community pitfalls, installed as a bundle.
+- **[dsh-doc-share](https://github.com/dawsondx/dsh-doc-share)** ([@dawsondx](https://github.com/dawsondx) · 2026-08-15) — Turns a DSH conversation into a formatted report with a cover, summary stats and per-turn chapters: turn-selector dialog (search / select-all / load older history), single-turn quick share, gen-UI rich components supported, and one-shot export to PNG / standalone HTML / PDF / Markdown.
 ## 🔍 How this list is maintained
 
 - **Built for users, not crawlers:** the front page is organized around "what I want to get done", not hundreds of repo names.


### PR DESCRIPTION
### 自荐 / Self-recommendation

**dsh-doc-share**：解决「复制 DSH 对话出去是一长串没结构的消息」的问题——把一次问答重排成带封面、内容摘要统计与按轮次分章的正式报告，一次生成 PNG 图片 / 单 HTML 文件 / PDF / Markdown 四种格式。轮次选择弹窗支持搜索、全选与加载更早历史，单轮可快捷分享，兼容 gen-UI 富组件。适合需要把 DSH 对话正式分享给同学、同事、客户或归档的用户。

**dsh-doc-share** solves "copying a DSH conversation out gives you an unstructured wall of messages": it restructures a Q&A into a formal report with a cover, summary stats and per-turn chapters, exporting to PNG / standalone HTML / PDF / Markdown in one shot. The turn-selector dialog supports search, select-all and loading older history; single turns can be shared quickly; gen-UI rich components are rendered faithfully. For anyone who wants to share DSH conversations formally with classmates, colleagues, clients, or their archives.

### 改动 / Changes

- 仅向 README.md 与 README_EN.md 的作者自荐区末尾各追加一行（中英对应），未改动其他人工维护内容，未提交生成文件。
- 本地已通过 node scripts/validate-curated.mjs（13 个 category overrides + 28 个自荐仓库，通过 GitHub API 校验）。
- 收录标准已满足：公开仓库 ✓ / dsh-plugin topic ✓（本次已补充）/ 已填写 description ✓（本次已修复乱码）/ 真实 DSH bundle ✓（带 dsh.bundle 清单 + cordis.patch.yml）