### PR TITLE
fix(curated): recategorize dsh-trace-compare under Developer Tools

### DIFF
--- a/data/curated.json
+++ b/data/curated.json
@@ -7,6 +7,7 @@
     "Han-1413141/dsh-cost-meter": "ui-experience",
     "howlma/dsh-desktop": "ui-experience",
     "KinGao294/dsh-skin": "ui-experience",
+    "lamost423/dsh-trace-compare": "developer-tools",
     "Nwflower/dsh-chat-import": "integrations-sharing",
     "omdsh-dev/dsh-genui": "ui-experience",
     "vlln/dsh-loop": "agents-workflows",


### PR DESCRIPTION
**中文**

我是 `lamost423/dsh-trace-compare` 的作者。目前它被自动分类到「设计、媒体与视觉」，应该是描述里的 "**visual**ize" 命中了 media-vision 的正则。它实际上是一个 agent 会话的调试/检查工具：解析 session log，把主干、失败支路、折返点画在墙钟时间轴上，支持双会话同轴 diff 对比——语义上和本分类里的 inspect/diff 工具一致，建议归入「开发者工具」。

按 CONTRIBUTING 的约定改在 `data/curated.json` 的 `category_overrides`（单行，未提交生成文件），本地 `node scripts/validate-curated.mjs` 通过（0 errors, 0 warnings）。

**English**

I'm the author of `lamost423/dsh-trace-compare`. It's currently auto-filed under "Design, Media & Vision" — most likely the "**visual**ize" in its description matched the media-vision pattern. The plugin is actually a debugging/inspection tool for agent sessions: it parses session logs and renders the main path, failed detours, and backtracks on a wall-clock timeline, with two-session same-axis diff comparison — semantically an inspect/diff developer tool, so `developer-tools` fits better.

Per CONTRIBUTING, the change is a single category override line in `data/curated.json` (no generated files committed); `node scripts/validate-curated.mjs` passes locally (0 errors, 0 warnings).