### PR TITLE
Add dsh-plugin-hub

### DIFF
--- a/README.md
+++ b/README.md
@@ -95,6 +95,7 @@ mindmap
 - **想把侧边栏升级成完整工作台**：[DSH-better-sidebar](https://github.com/omdsh-dev/DSH-better-sidebar) —— 内置文件渲染编辑、终端、Git 与子代理，并支持第三方扩展注册新 Tab。
 - **想让工作状态行活过来**：[working-activity](https://github.com/ccch1mneyyy/working-activity) —— 实时显示工具动态与进度、俏皮文案、模型自述与上下文预警，等待时不再无聊。
 - **想在开发对话里直接检查和操作当前网页**：[dsh-browser](https://github.com/Lum1104/dsh-browser) —— Chrome 侧边栏扩展，让 DSH 直接操作你的浏览器：无需视觉能力，即可在当前对话里授权页面、读取并执行网页操作。
+- **想集中管理已装插件、从多源市场一键装配**：[dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) —— DSH 插件管理面板：一键启停 + 多源市场 + 静态索引（500+ 插件 / 300 技能）+ 技能安装/停用 + 套装一键装配 + 框架升级适配。
 
 | | | |
 | :---: | :---: | :---: |


### PR DESCRIPTION
## 收录申请：dsh-plugin-hub

[Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) — DSH 插件管理面板与市场：

- 一键启用/停用已安装插件（HMR 生效），基础设施保护
- 多源插件市场：GitHub / Gitee 直装 / 自定义搜索源、多源汇总、★ 官方筛选
- 静态索引市场：jsDelivr CDN 分发 500+ 插件 / 300 技能，零 GitHub API 调用
- 技能市场：搜索（agent-skills/claude-skills/dsh-skill）、一键安装/停用/删除、系统保护
- 套装（submodule 聚合仓库）一键装配：bundle 插件 / 技能 / agent 预设 / 普通插件
- 自动收录 CI（每 6 小时刷新索引）、框架升级适配（配置备份 + 补丁重打）
- 已打 dsh-plugin topic

适用场景：想让 DSH 插件管理更省心的人——无需手动翻 GitHub 找插件，面板内一键启停、多源搜索、静态索引即开即用，技能与套装也能批量装配。

本次改动：在 README.md「🧰 界面与工作台」精选推荐分类下新增一行条目（未提交任何生成文件）。如需同步英文版 README_EN.md，可后续补充。

感谢收录！
