### PR TITLE
Add dsh-plugin-hub under Ecosystem entry points (zh + en)

### DIFF
--- a/README.md
+++ b/README.md
@@ -183,7 +183,7 @@ mindmap
 ### 🌱 生态入口
 
 - **想先审查、再安装插件（安全第一）**：[dsh-desktop-safe-market](https://github.com/bruc3van/dsh-desktop-safe-market) —— 先审查再安装的 DSH 市场：目录来自本清单每日快照 + 人工精选，「安全安装」不执行任何命令——把安全审查提示词交给 Agent 实际读仓库代码，确认干净后由你决定是否用官方命令安装；市场默认关闭、开启才联网，插件自身没有任何执行安装的接口。
-- **想在 DSH 界面里直接逛插件市场**：[dsh-market](https://github.com/dsh-market/dsh-market) · [DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) —— dsh-market 把市场做进 DSH：浏览、搜索、一键安装；DSH-Plugins-Marketplace 覆盖全部 GitHub dsh-plugin 插件的一键浏览、安装与更新。
+- **想在 DSH 界面里直接逛插件市场**：[dsh-market](https://github.com/dsh-market/dsh-market) · [DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) —— dsh-market 把市场做进 DSH：浏览、搜索、一键安装；DSH-Plugins-Marketplace 覆盖全部 GitHub dsh-plugin 插件的一键浏览、安装与更新。 [dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) —— 插件管理面板 + 市场：一键启停/检测更新/框架一键升级，覆盖全部 GitHub dsh-plugin 插件与技能。
 
 | | | |
 | :---: | :---: | :---: |

--- a/README_EN.md
+++ b/README_EN.md
@@ -183,7 +183,7 @@ To browse every project in a category, see [CATALOG.md](./CATALOG.md).
 ### 🌱 Ecosystem entry points
 
 - **Want to review before you install (security first)**: [dsh-desktop-safe-market](https://github.com/bruc3van/dsh-desktop-safe-market) — a review-before-install DSH marketplace: the feed comes from this list's daily snapshot plus human curation, and "Safe install" executes nothing — it hands a security-review prompt to the agent, which actually reads the plugin's code, and only after it comes back clean do you decide whether to run the official install command. Off by default — it goes online only once you enable it, and the plugin itself has no interface that can run an install.
-- **Want a plugin market right inside the DSH UI**: [dsh-market](https://github.com/dsh-market/dsh-market) · [DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) — dsh-market brings browse/search/one-click-install into the DSH UI; DSH-Plugins-Marketplace covers one-click browse/install/update of every GitHub dsh-plugin plugin.
+- **Want a plugin market right inside the DSH UI**: [dsh-market](https://github.com/dsh-market/dsh-market) · [DSH-Plugins-Marketplace](https://github.com/bradeGithub/DSH-Plugins-Marketplace) — dsh-market brings browse/search/one-click-install into the DSH UI; DSH-Plugins-Marketplace covers one-click browse/install/update of every GitHub dsh-plugin plugin. · [dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) - plugin manager & marketplace: one-click enable/disable, update detection, one-click framework upgrade, covering all GitHub dsh-plugin plugins & skills.
 
 | | | |
 | :---: | :---: | :---: |


### PR DESCRIPTION
## 收录申请：dsh-plugin-hub

[Noob-stupid/dsh-plugin-hub](https://github.com/Noob-stupid/dsh-plugin-hub) — DSH 插件管理面板 + 市场，按评审意见归入「🌱 生态入口 / Ecosystem entry points」分类（中英两处）：

- **插件管理面板**：已安装插件一键启停（基础设施受保护）、版本检测与一键更新、删除卸载
- **插件市场**：500+ dsh-plugin 插件 / 300 技能，多源检索（GitHub/Gitee/自定义），CI 每 6 小时自动收录
- **🎯 框架一键升级**（v0.3.13）：备份→在线安装→校验→失败回滚→自动重启；升级后自动重链框架配套包
- 技能 / 套装一键安装、软件源管理、AI 兜底（费用透明授权）
- 已发布 npm：`@noob-stupid/dsh-plugin-console@0.3.13`（`dsh plugin add` 官方路径）
- MIT、`dsh-plugin` topic、★64、已收录于目录与榜单

**本次按评审意见：**
1. ✅ 中英同步：英文条目已加到 `README_EN.md`（Ecosystem entry points 分类）
2. ✅ 分类调整：条目移到「🌱 生态入口 / Ecosystem entry points」（中英两处）

（上一 PR #100 因修改不完整关闭，本次重新基于最新 main 提交，两处均已完整修正。）

感谢收录！
