### PR TITLE
fix: categorize chumingjun/dsh-harness-one as agents-workflows

### DIFF
--- a/data/curated.json
+++ b/data/curated.json
@@ -13,7 +13,8 @@
     "omdsh-dev/dsh-genui": "ui-experience",
     "vlln/dsh-loop": "agents-workflows",
     "vlln/plugin-registry": "ecosystem-resources",
-    "vlln/whale-girl": "ui-experience"
+    "vlln/whale-girl": "ui-experience",
+    "chumingjun/dsh-harness-one": "agents-workflows"
   },
   "leaderboard_exclusions": {
     "01men/ybkk-AIOS": "Kept out of the star board: a plugin market / store / directory — the market cannot include another market. Stays in the catalog.",


### PR DESCRIPTION
Hi! I am the author of [chumingjun/dsh-harness-one](https://github.com/chumingjun/dsh-harness-one) (currently listed under `media-vision`).

The "Visual" in its description refers to the visual workflow canvas (drag-and-drop DAG editor), not image/vision capabilities — the plugin does not handle images or media at all. It is a multi-agent DAG workflow orchestrator: scheduling, approvals, retries, restart recovery, and Feishu notifications.

This PR adds a `category_overrides` entry to re-file it under `agents-workflows`, which matches both its function and the other workflow-orchestrator entries there. No generated files are touched, per CONTRIBUTING.

Thanks!