### PR TITLE
Add dsh-ppt-master and dsh-skill-hub to Recently Joined

### DIFF
--- a/README.md
+++ b/README.md
@@ -325,6 +325,8 @@ mindmap
 | [addozhang/dsh-discord](https://github.com/addozhang/dsh-discord) | Discord 优先适配器：在 Discord 服务器里开会话、流式输出、审批与控制，把 Harness 接到公会频道。 | 2026-08-30 |
 | [liyi3068238601-oss/dsh-comfyui-ctl](https://github.com/liyi3068238601-oss/dsh-comfyui-ctl) | 原生 ComfyUI 控制：查队列、中断/清理任务、看历史与产出、盘点模型，上传图片并提交生成工作流。 | 2026-08-31 |
 | [Crosery/dsh-viewer](https://github.com/Crosery/dsh-viewer) | Everything renders：一张 `display_file` 工具把图片、视频、音频、PDF、Office 与本地网页以内联播放器渲到 Web UI。 | 2026-08-31 |
+| [pn1024/dsh-ppt-master](https://github.com/pn1024/dsh-ppt-master) | PPT Master：AI 驱动的演示文稿工作流——生成可编辑 PPTX、SVG 快照、原生模板填充与 PPTX 增强，一站式完成幻灯片制作。 | 2026-09-01 |
+| [pn1024/dsh-skill-hub](https://github.com/pn1024/dsh-skill-hub) | 技能市场：聚合 SkillHub + ClawHub 双源搜索技能，侧边栏入口 + 浮层面板预览 README，一键安装/卸载，聊天栏快速选择技能。 | 2026-09-01 |
 
 ## 📣 作者自荐
 

--- a/README_EN.md
+++ b/README_EN.md
@@ -325,6 +325,8 @@ Manually screened recent projects, updated from time to time:
 | [addozhang/dsh-discord](https://github.com/addozhang/dsh-discord) | Discord-first adapter: sessions, streaming, approvals and controls from a Discord guild, so Harness lives in the channel. | 2026-08-30 |
 | [liyi3068238601-oss/dsh-comfyui-ctl](https://github.com/liyi3068238601-oss/dsh-comfyui-ctl) | Native ComfyUI control: inspect queues, cancel/clear jobs, browse history and outputs, inventory models, upload images and submit generation workflows. | 2026-08-31 |
 | [Crosery/dsh-viewer](https://github.com/Crosery/dsh-viewer) | Everything renders: one `display_file` tool that puts images, video, audio, PDF, Office docs and local web pages inline in the web UI with a real player. | 2026-08-31 |
+| [pn1024/dsh-ppt-master](https://github.com/pn1024/dsh-ppt-master) | PPT Master: AI-driven presentation workflow - generate editable PPTX decks, SVG snapshots, native template filling, and PPTX enhancement in one plugin. | 2026-09-01 |
+| [pn1024/dsh-skill-hub](https://github.com/pn1024/dsh-skill-hub) | Skill marketplace: aggregated SkillHub + ClawHub search, sidebar entry + overlay panel with README preview, one-click install/uninstall, and a chat-input skill quick-pick. | 2026-09-01 |
 
 ## 📣 Author showcase
 


### PR DESCRIPTION
## 推荐两个 DSH 插件加入「最近加入生态」

### 1. dsh-ppt-master

- **仓库**: https://github.com/pn1024/dsh-ppt-master
- **分类**: ecosystem-resources
- **简介**: PPT Master skill packaged as a DeepSeek Harness (dsh) plugin: AI-driven presentation workflow for editable PPTX decks, SVG snapshots, native template filling, and PPTX enhancement.
- **Topic**: dsh-plugin, deepseek-harness, ppt, skill
- **License**: MIT
- **已收录**: approved.json (2026-09-01)

### 2. dsh-skill-hub

- **仓库**: https://github.com/pn1024/dsh-skill-hub
- **分类**: ui-experience
- **简介**: dsh plugin - skill marketplace (SkillHub + ClawHub) with sidebar entry, overlay panel, and chat input quick-pick
- **Topic**: dsh-plugin, deepseek-harness, skill-marketplace, clawhub, skillhub
- **License**: MIT

两个插件均已满足收录标准：公开仓库、带 dsh-plugin Topic、已填写 description。

已在 README.md 和 README_EN.md 的「最近加入」区域各添加中英文条目。